### PR TITLE
Add basic Jest tests

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,25 +1,26 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 
+export const compute = (a, operator, b) => {
+  switch (operator) {
+    case '+':
+      return a + b;
+    case '-':
+      return a - b;
+    case '×':
+      return a * b;
+    case '÷':
+      return b === 0 ? 0 : a / b;
+    default:
+      return b;
+  }
+};
+
 export default function App() {
   const [display, setDisplay] = useState('0');
   const [first, setFirst] = useState(null);
   const [op, setOp] = useState(null);
 
-  const compute = (a, operator, b) => {
-    switch (operator) {
-      case '+':
-        return a + b;
-      case '-':
-        return a - b;
-      case '×':
-        return a * b;
-      case '÷':
-        return b === 0 ? 0 : a / b;
-      default:
-        return b;
-    }
-  };
 
   const handlePress = (val) => {
     if (val === 'C') {

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,0 +1,11 @@
+import { compute } from '../App';
+
+describe('compute', () => {
+  test('adds numbers', () => {
+    expect(compute(2, '+', 3)).toBe(5);
+  });
+
+  test('handles division by zero', () => {
+    expect(compute(2, '÷', 0)).toBe(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "react-native start",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "jest"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- expose `compute` for testing
- add Jest tests for compute
- run tests using `npm test`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d372a9c208324bc9235eaafdb9aa4